### PR TITLE
add link for GitHub issue raising + button to open instructions panel

### DIFF
--- a/views/visualise.ejs
+++ b/views/visualise.ejs
@@ -24,20 +24,28 @@
 
 			</div>
 			<div class="panel panel-default">
+<div class="fluid-row" style="display: block;">
+<button onclick="{if(document.getElementById('instruction-row').style.display === 'block'){ document.getElementById('instruction-row').style.display = 'none';} else {document.getElementById('instruction-row').style.display = 'block';}}">Instructions</button>
+<button onclick="window.open('https://github.com/kitab-project-org/kitab-project-org.github.io/issues/new?assignees=mabarber92&labels=applications&template=bug-report--tweaks--kitab-applications.md&title=Application+Bug:+Pairwise+Book+Visualisation','_blank');" type="button">Raise an issue</button>
 
-				<div class="fluid-row" id="instruction-row" style="display: none;">
+</div>
 
-					<p class='instruction'>This KITAB app can generate visualisation for V1 and V2 type of srt files.
-						The V1 srt files for the whole corpus are available <a
-							href='http://dev.kitab-project.org/passim1017/' target='_blank'>here.</a>
-						The file needs to be exacted before I can be used to generate visualisation
-						<br />
-						<br /> V2 SRT (Sira) files are available <a href='http://dev.kitab-project.org/passim01022019'
-							target='_blank'>here</a>.
-						The default SRT (V2) file loaded to this visualisation is Shamela0026039-ara1_JK000467-ara1.
-						'Choose-File' and click upload to generate the visualisation.</p>
-					<p class='instruction'>March 2020</p>
-				</div>
+<div class="fluid-row" id="instruction-row" style="display: none;">
+<p class='instruction'>
+  This KITAB app can generate visualisations for V1 
+  and V2 types of passim output files. 
+  The files can be downloaded from the 
+  <a href="https://kitab-corpus-metadata.azurewebsites.net/arabic-kitab-version.html" target="_blank">KITAB internal metadata app</a>
+  .
+</p>
+<p class='instruction'>
+  Click the 'Choose File' button to select your file 
+  and click "Upload" to generate the visualisation.
+</p>
+<p class='instruction'>
+  March 2020
+</p>
+</div>
 				<ul class="list-group">
 					<li class="list-group-item" id='uploadfile-panel'>
 						<div class="row toggle row-header" id="dropdown-detail-1" data-toggle="detail-1">


### PR DESCRIPTION
Hi Sohail, 
We discussed today in our preparation for Friday's user group session that the visualization app should include a link for raising issues with the app or data. I added a button that brings you to the relevant page and opens the relevant issue template. 
While I was doing that, I saw that there is actually a hidden div with instructions, but there is no way to make that div visible; so I added another button that toggles that instructions div. 