### PR TITLE
support for books not found in metadata

### DIFF
--- a/public/javascripts/js/script.js
+++ b/public/javascripts/js/script.js
@@ -67,9 +67,29 @@
 
       var srtData = e.data[0];
       var selectedMetadata = e.data[1];
+      
+      // get highest milestoneID from srtData :
+      // (to be used if the book is not found in the metadata)
+      for (var i=0; i<selectedMetadata.length; i++) {
+        var chunk_id = "book" + (i+1) + "_chunk";
+        var lastChunk = 0;
+        for (const row of srtData){
+          if (row[chunk_id] > lastChunk){
+            lastChunk = row[chunk_id];
+          }
+        }
+        console.log("lastChunk: " + lastChunk);
+        selectedMetadata[i]["last_reused_chunk"] = lastChunk;
+      }
+      console.log("selected metadata after adding last reused chunk:");
+      console.log(selectedMetadata);
 
       graph.setMaxValue(selectedMetadata.map(function (d) {
-        return d.book_chunk_count;
+        if (d.book_chunk_count){
+          return d.book_chunk_count;
+        } else {
+          return d.last_reused_chunk;
+        }
       }));
 
       graph.initData(srtData);

--- a/public/javascripts/web-worker/load-chunks-worker.js
+++ b/public/javascripts/web-worker/load-chunks-worker.js
@@ -107,6 +107,7 @@ function loadBook(bookName, pageNumber, pageIndex, config) {
         bookData.pageHistory[pageNumber] = xhr.responseText;
         bookOnLoad(xhr.responseText, bookName, pageIndex);
       } else {
+        bookOnLoad("not found", bookName, pageIndex);
         console.error(xhr.statusText);
       }
     }

--- a/public/javascripts/web-worker/load-initial-data-worker.js
+++ b/public/javascripts/web-worker/load-initial-data-worker.js
@@ -109,6 +109,23 @@ function parseMetaDataFile(fileStr, config, bookUris) {
     }
     return booksToFind <= 0;
   });
+  
+  console.log("Check for books that were not found in metadata:");
+  for (const [bookId, val] of Object.entries(bookIdHash)) {
+    if (val === true) {  // not replaced by metadata yet
+      console.log("Adding default metadata for missing book " + bookId);
+      bookIdHash[bookId] = {
+        book_id: bookId, 
+        author_died: "not in metadata",
+        book_author: "not in metadata",
+        book_title: "not in metadata",
+        book_word_count: 0,
+        book_chunk_count: 0,
+        book_uri: bookId};
+      console.log(bookIdHash[bookId]);
+    }
+  }
+  
 
   return config.bookSequence.map(function (bookName) {
     return bookIdHash[bookUris[bookName]];


### PR DESCRIPTION
Hi Sohail, 

I noticed that when a book was not found in the metadata, the script would fail and the graph would not be displayed. This is especially problematic if we run passim locally on a few files between official passim runs.

I adapted the script so that if one or both of the books were not found in the metadata, the graph is still displayed: 

* author and title information on top of the graph now say "not found in metadata" if the book was not found in the metadata
* word count and chunk count are set to 0
* an additional measure is introduced: last_reused_chunk: the highest chunk id number registered in the csv file (will be used instead of chunk_count to set the end of the book on the X axis if chunk_count === 0 because the book was not found in the metadata)
* if the input text file could not be found in i.mech, a placeholder text "not found" is passed on rather than an error, so that the code does not break.